### PR TITLE
Potential fix for code scanning alert no. 663: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,6 +2,8 @@ name: Get latest release version
 on:
   schedule:
     - cron:  '10 1 * * *'
+permissions:
+  contents: write
 jobs:
   get-version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/dark-vex/zabbix-docker-telegram/security/code-scanning/663](https://github.com/dark-vex/zabbix-docker-telegram/security/code-scanning/663)

Add an explicit `permissions` block in `.github/workflows/main.yaml` to limit token scope to what the job needs.

Best fix here: define workflow-level permissions right under `on:` (or `name:`) with `contents: write`, because this workflow commits and pushes changes to the repository. `contents: write` is the minimum required scope for that behavior. This preserves current functionality while making permissions explicit and least-privilege compared to unrestricted defaults.

Change region: in `.github/workflows/main.yaml`, insert:

```yaml
permissions:
  contents: write
```

between the trigger section and `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
