### PR TITLE
Potential fix for code scanning alert no. 578: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,9 @@ on:
       - Dockerfile
       - requirements.txt
 
+permissions:
+  contents: read
+
 jobs:
   build_zabbix_server:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/dark-vex/zabbix-docker-telegram/security/code-scanning/578](https://github.com/dark-vex/zabbix-docker-telegram/security/code-scanning/578)

Add an explicit `permissions` block to the workflow so token rights are intentionally limited.  
Best fix here (without changing functionality) is to add workflow-level minimal read permission:

- `contents: read`

This satisfies checkout needs and addresses CodeQL’s requirement. Since image push/login uses `secrets.REPO_SCOPED_TOKEN` (not `GITHUB_TOKEN`), no extra `packages: write` permission is required for `GITHUB_TOKEN` in this snippet.  
Edit `.github/workflows/build.yaml` near the top-level keys (after `on:` block and before `jobs:` is the clearest placement).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
