### PR TITLE
Sign release-version commits with a GitHub App token

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,9 +10,16 @@ jobs:
   get-version:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
-          token: ${{ secrets.REPO_SCOPED_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Fetch release version
         run: |
@@ -25,7 +32,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.REPO_SCOPED_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           sign-commits: true
           branch: update/zabbix-server-7.0
           delete-branch: true
@@ -41,5 +48,5 @@ jobs:
         if: steps.cpr.outputs.pull-request-operation == 'created'
         run: gh pr merge --auto --squash "${{ steps.cpr.outputs.pull-request-number }}"
         env:
-          GH_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
peter-evans/create-pull-request's sign-commits option only produces a GitHub-verified commit when authenticated as the default GITHUB_TOKEN or a GitHub App installation token; a personal access token (the REPO_SCOPED_TOKEN we switched to so required checks would trigger) does not get auto-signed, so the ruleset's verified-signature requirement kept blocking the PR. Mint a short-lived GitHub App token via actions/create-github-app-token and use it everywhere the PAT was used, which satisfies both constraints: checks still trigger on the PR, and the commit is verified.


Claude-Session: https://claude.ai/code/session_01WXeQg3jX2LLU3SjP7phAP5